### PR TITLE
Tests for zonecut

### DIFF
--- a/src/dnstest_definitions.erl
+++ b/src/dnstest_definitions.erl
@@ -25,6 +25,17 @@ erldns_definitions() ->
              ]},
            {additional, []}
           }}}},
+    {ns_zonecut_child_cname, {
+        {question, {"cnamerecord.zonecut.withzonecut.com", ?DNS_TYPE_CNAME}},
+        {header, #dns_message{rc=?DNS_RCODE_NOERROR, rd=false, qr=true, tc=false, aa=false, oc=?DNS_OPCODE_QUERY}},
+        {records, {
+           {answers, []},
+           {authority, [
+                {<<"zonecut.withzonecut.com">>, ?DNS_CLASS_IN, ?DNS_TYPE_NS, 120, #dns_rrdata_ns{dname = <<"ns1.cutwithzonecut.com">>}},
+                {<<"zonecut.withzonecut.com">>, ?DNS_CLASS_IN, ?DNS_TYPE_NS, 120, #dns_rrdata_ns{dname = <<"ns2.cutwithzonecut.com">>}}
+             ]},
+           {additional, []}
+          }}}},
     {ns_recursion_breakout, {
         {question, {"rns.example.com", ?DNS_TYPE_NS}},
         {header, #dns_message{rc=?DNS_RCODE_NOERROR, rd=false, qr=true, tc=false, aa=false, oc=?DNS_OPCODE_QUERY}},

--- a/src/dnstest_definitions.erl
+++ b/src/dnstest_definitions.erl
@@ -14,6 +14,17 @@ definitions() ->
 
 erldns_definitions() ->
   [
+    {ns_zonecut, {
+        {question, {"child.zonecut.withzonecut.com", ?DNS_TYPE_MX}},
+        {header, #dns_message{rc=?DNS_RCODE_NOERROR, rd=false, qr=true, tc=false, aa=false, oc=?DNS_OPCODE_QUERY}},
+        {records, {
+           {answers, []},
+           {authority, [
+                {<<"zonecut.withzonecut.com">>, ?DNS_CLASS_IN, ?DNS_TYPE_NS, 120, #dns_rrdata_ns{dname = <<"ns1.cutwithzonecut.com">>}},
+                {<<"zonecut.withzonecut.com">>, ?DNS_CLASS_IN, ?DNS_TYPE_NS, 120, #dns_rrdata_ns{dname = <<"ns2.cutwithzonecut.com">>}}
+             ]},
+           {additional, []}
+          }}}},
     {ns_recursion_breakout, {
         {question, {"rns.example.com", ?DNS_TYPE_NS}},
         {header, #dns_message{rc=?DNS_RCODE_NOERROR, rd=false, qr=true, tc=false, aa=false, oc=?DNS_OPCODE_QUERY}},


### PR DESCRIPTION
Tests for handling a zonecut in [erldns](https://github.com/dnsimple/erldns/pull/89).

* Child of a zonecut should not return answer, only authority
* CName child of a zonecut that points outside the zone should not return answer, only authority